### PR TITLE
Add drug router with CRUD operations and JWT middleware

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import routerStudyPlan from "./modules/study-plan/router/studyPlan.router";
 import { JwtService } from "./utils/jwt/jwt.service";
 import routerUser from "./modules/user/router/user.router";
 import routerRole from "./modules/role/router/role.router";
+import routerDrug from "./modules/drug/router/drug.router";
 
 const app = express();
 const jwtService = new JwtService();
@@ -16,13 +17,13 @@ app.use(express.json());
 app.use("/api/access/pharma-guide", routerAccess);
 
 app.use(
-  "/api/pharma-guide/",
+  "/api/pharma-guide",
   jwtService.verifyTokenMiddleware.bind(jwtService),
   routerStudyPlan
 );
 
 app.use(
-  "/api/pharma-guide/",
+  "/api/pharma-guide",
   jwtService.verifyTokenMiddleware.bind(jwtService),
   routerUser
 );
@@ -33,6 +34,12 @@ app.use(
   "/api/pharma-guide/setting",
   jwtService.verifyTokenMiddleware.bind(jwtService),
   routerRole
+);
+
+app.use(
+  "/api/pharma-guide",
+  jwtService.verifyTokenMiddleware.bind(jwtService),
+  routerDrug
 );
 
 export default app;

--- a/src/modules/Drug/router/drug.router.ts
+++ b/src/modules/Drug/router/drug.router.ts
@@ -1,0 +1,17 @@
+import { Router } from "express";
+import { DrugController } from "../controller/drug.controller";
+
+const routerDrug = Router();
+const drugController = new DrugController();
+
+routerDrug.post("/drug", drugController.createDrug.bind(drugController));
+
+routerDrug.get("/drugs", drugController.getDrugs.bind(drugController));
+
+routerDrug.get("/drug/:id", drugController.getDrugUser.bind(drugController));
+
+routerDrug.put("/drug/:id", drugController.updateDrug.bind(drugController));
+
+routerDrug.delete("/drug/:id", drugController.deleteDrug.bind(drugController));
+
+export default routerDrug;

--- a/src/modules/study-plan/router/studyPlan.router.ts
+++ b/src/modules/study-plan/router/studyPlan.router.ts
@@ -10,7 +10,7 @@ routerStudyPlan.post(
 );
 
 routerStudyPlan.get(
-  "/study-plans/me",
+  "/study-plans",
   studyPlanController.getStudyPlan.bind(studyPlanController)
 );
 


### PR DESCRIPTION
Introduce a drug router that supports CRUD operations for drugs and integrate it into the application with JWT middleware for authentication.