### PR TITLE
Add Prompt and ManagementIa models to Prisma schema

### DIFF
--- a/prisma/migrations/20250520040122_create_table_prompt/migration.sql
+++ b/prisma/migrations/20250520040122_create_table_prompt/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "Prompt" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(100) NOT NULL,
+    "prompt" TEXT NOT NULL,
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Prompt_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/migrations/20250520040202_create_table_managemet_ia/migration.sql
+++ b/prisma/migrations/20250520040202_create_table_managemet_ia/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "ManagementIa" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(100) NOT NULL,
+    "provider" VARCHAR(100) NOT NULL,
+    "api_key" TEXT NOT NULL,
+    "model" VARCHAR(100) NOT NULL,
+    "base_url" VARCHAR(255) NOT NULL,
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ManagementIa_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/migrations/20250520040449_create_relation_prompt_with_management_ia/migration.sql
+++ b/prisma/migrations/20250520040449_create_relation_prompt_with_management_ia/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `promptId` to the `ManagementIa` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "ManagementIa" ADD COLUMN     "promptId" INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "ManagementIa" ADD CONSTRAINT "ManagementIa_promptId_fkey" FOREIGN KEY ("promptId") REFERENCES "Prompt"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,6 +82,7 @@ model Drug {
 }
 
 model Prompt {
+  id     Int    @id @default(autoincrement()) @db.Integer
   name   String @db.VarChar(100)
   prompt String @db.Text
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,7 +82,10 @@ model Drug {
 }
 
 model Prompt {
-  id          Int    @id @default(autoincrement()) @db.Integer
-  name        String @db.text
-  description String @db.text
+  name   String @db.VarChar(100)
+  prompt String @db.Text
+
+  isDeleted Boolean  @default(false)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,3 +90,16 @@ model Prompt {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
+
+model ManagementIa {
+  id       Int    @id @default(autoincrement()) @db.Integer
+  name     String @db.VarChar(100)
+  provider String @db.VarChar(100)
+  api_key  String @db.Text
+  model    String @db.VarChar(100)
+  base_url String @db.VarChar(255)
+
+  isDeleted Boolean  @default(false)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,3 +80,9 @@ model Drug {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
+
+model Prompt {
+  id          Int    @id @default(autoincrement()) @db.Integer
+  name        String @db.text
+  description String @db.text
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,6 +86,8 @@ model Prompt {
   name   String @db.VarChar(100)
   prompt String @db.Text
 
+  managementIa ManagementIa[]
+
   isDeleted Boolean  @default(false)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -98,6 +100,9 @@ model ManagementIa {
   api_key  String @db.Text
   model    String @db.VarChar(100)
   base_url String @db.VarChar(255)
+
+  promptId Int
+  prompt   Prompt @relation(fields: [promptId], references: [id])
 
   isDeleted Boolean  @default(false)
   createdAt DateTime @default(now())


### PR DESCRIPTION
Introduce the Prompt and ManagementIa models with relevant fields and establish a relationship between them in the Prisma schema. Include necessary migrations for the database tables.