### PR TITLE
Add management IA CRUD operations and status handling

### DIFF
--- a/prisma/migrations/20250523151702_add_column_status_in_managemen_ia/migration.sql
+++ b/prisma/migrations/20250523151702_add_column_status_in_managemen_ia/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `status` to the `ManagementIa` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "ManagementIa" ADD COLUMN     "status" VARCHAR(100) NOT NULL;

--- a/prisma/migrations/20250523152140_update_type_colummn_in_management_ia_string_a_boolean/migration.sql
+++ b/prisma/migrations/20250523152140_update_type_colummn_in_management_ia_string_a_boolean/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - The `status` column on the `ManagementIa` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "ManagementIa" DROP COLUMN "status",
+ADD COLUMN     "status" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,12 +94,13 @@ model Prompt {
 }
 
 model ManagementIa {
-  id       Int    @id @default(autoincrement()) @db.Integer
-  name     String @db.VarChar(100)
-  provider String @db.VarChar(100)
-  api_key  String @db.Text
-  model    String @db.VarChar(100)
-  base_url String @db.VarChar(255)
+  id       Int     @id @default(autoincrement()) @db.Integer
+  name     String  @db.VarChar(100)
+  provider String  @db.VarChar(100)
+  api_key  String  @db.Text
+  model    String  @db.VarChar(100)
+  base_url String  @db.VarChar(255)
+  status   Boolean @default(false)
 
   promptId Int
   prompt   Prompt @relation(fields: [promptId], references: [id])

--- a/src/modules/Ia-management/controller/ia-management.controller.ts
+++ b/src/modules/Ia-management/controller/ia-management.controller.ts
@@ -52,6 +52,7 @@ export class ManagementIaController {
   ): Promise<void> {
     try {
       const managements = await this.managementService.getManagement();
+
       res.status(200).json({
         data: managements,
       });
@@ -62,6 +63,38 @@ export class ManagementIaController {
       );
       res.status(500).json({
         message: "Error getting management: ",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  public async getOneManagement(
+    req: Request,
+    res: Response,
+    _next: NextFunction
+  ): Promise<void> {
+    try {
+      const managementId = Number(req.params.id);
+
+      if (isNaN(managementId)) {
+        res.status(400).json({ message: "Invalid user ID" });
+        return;
+      }
+
+      const management = await this.managementService.getOneMaganegement(
+        managementId
+      );
+
+      res.status(200).json({
+        data: management,
+      });
+    } catch (error: any) {
+      console.error(
+        "A error ocurred fetching the management IA :",
+        error instanceof Error ? error.message : error
+      );
+      res.status(500).json({
+        message: "Error getting the management: ",
         error: error instanceof Error ? error.message : String(error),
       });
     }

--- a/src/modules/Ia-management/controller/ia-management.controller.ts
+++ b/src/modules/Ia-management/controller/ia-management.controller.ts
@@ -44,4 +44,26 @@ export class ManagementIaController {
       });
     }
   }
+
+  public async getManegement(
+    _req: Request,
+    res: Response,
+    _next: NextFunction
+  ): Promise<void> {
+    try {
+      const managements = await this.managementService.getManagement();
+      res.status(200).json({
+        data: managements,
+      });
+    } catch (error: any) {
+      console.error(
+        "A error ocurred fetching managment IA:",
+        error instanceof Error ? error.message : error
+      );
+      res.status(500).json({
+        message: "Error getting management: ",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
 }

--- a/src/modules/Ia-management/controller/ia-management.controller.ts
+++ b/src/modules/Ia-management/controller/ia-management.controller.ts
@@ -99,4 +99,81 @@ export class ManagementIaController {
       });
     }
   }
+
+  public async updateManagement(
+    req: Request,
+    res: Response,
+    _next: NextFunction
+  ): Promise<void> {
+    try {
+      const managementId = Number(req.params.id);
+      const dataManagementUpdate = req.body;
+
+      if (!dataManagementUpdate || isNaN(managementId)) {
+        res
+          .status(400)
+          .json({ message: "Invalid management ID or missing update data" });
+        return;
+      }
+
+      const managementUpdate = await this.managementService.updateManegement(
+        managementId,
+        dataManagementUpdate
+      );
+
+      if (!managementUpdate) {
+        res.status(404).json({
+          message: "Management not found or update failed",
+        });
+        return;
+      }
+
+      res.status(200).json({
+        message: "Management updated successfully",
+        data: managementUpdate,
+      });
+    } catch (error: any) {
+      console.error("An error occurred updating management:", error?.message);
+      res.status(500).json({
+        message: "An error occurred updating management",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  public async deleteManagement(
+    req: Request,
+    res: Response,
+    _next: NextFunction
+  ): Promise<void> {
+    try {
+      const managementId = Number(req.params.id);
+      if (isNaN(managementId)) {
+        res.status(400).json({
+          message: "Invalid management ID",
+        });
+        return;
+      }
+
+      const deleteManagement = await this.managementService.deleteManegement(
+        managementId
+      );
+      if (!deleteManagement) {
+        res.status(404).json({
+          message: "Management not found or could not be deleted",
+        });
+      }
+
+      res.status(204).send();
+    } catch (error: any) {
+      console.error(
+        "An error occurred deleting management:",
+        error instanceof Error ? error.message : error
+      );
+      res.status(500).json({
+        message: "An error occurred deleting management",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
 }


### PR DESCRIPTION
Introduce methods for fetching, updating, and deleting management IA entries. Implement a status column to enforce a single active record, ensuring only one management IA can be active at a time.