### PR TITLE
Add 'type' column to ManagementIa model and migration

### DIFF
--- a/prisma/migrations/20250705033602_add_column_type_in_management_ia/migration.sql
+++ b/prisma/migrations/20250705033602_add_column_type_in_management_ia/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `type` to the `ManagementIa` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "ManagementIa" ADD COLUMN     "type" VARCHAR(50) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,7 @@ model Drug {
 model ManagementIa {
   id                 Int      @id @default(autoincrement())
   name               String   @db.VarChar(100)
+  type               String   @db.VarChar(50)
   provider           String   @db.VarChar(100)
   api_key            String
   model              String   @db.VarChar(100)


### PR DESCRIPTION
Introduce a new 'type' column in the ManagementIa model and update the database schema accordingly. This change requires careful handling for existing data due to the absence of a default value.